### PR TITLE
change path of TravisCI status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/joseph2rs/Website-Volontaria.svg?branch=master)](https://travis-ci.org/joseph2rs/Website-Volontaria)
+[![Build Status](https://travis-ci.org/Volontaria/Website-Volontaria.svg?branch=develop)](https://travis-ci.org/Volontaria/Website-Volontaria)
 # Volontaria
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 1.5.0.


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | None

---

## What have you changed ?
Fix the path of the TravisCI image who link to the Travis of @joseph2rs 

## How did you change it ?
Just change the path on the url to the Travis of the organization

## Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 