### PR TITLE
add is_active http param on get cycles

### DIFF
--- a/src/app/components/pages/home-page/home-page.component.ts
+++ b/src/app/components/pages/home-page/home-page.component.ts
@@ -1,8 +1,8 @@
-import { Component, OnInit, ViewEncapsulation } from '@angular/core';
-import {Cycle} from '../../../models/cycle';
-import {CycleService} from '../../../services/cycle.service';
-import {User} from '../../../models/user';
-import {UserService} from '../../../services/user.service';
+import { Component, ViewEncapsulation } from '@angular/core';
+import { Cycle } from '../../../models/cycle';
+import { CycleService } from '../../../services/cycle.service';
+import { User } from '../../../models/user';
+import { UserService } from '../../../services/user.service';
 
 @Component({
   selector: 'app-home',
@@ -22,7 +22,7 @@ export class HomePageComponent {
         this.user = data;
       }
     );
-    this.cycleService.getCycles().subscribe(
+    this.cycleService.getCycles(true).subscribe(
       data => {
         this.cycles = data.results.map(c => new Cycle(c) );
       }

--- a/src/app/services/cycle.service.ts
+++ b/src/app/services/cycle.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@angular/core';
 import 'rxjs/add/operator/map';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 import GlobalService from './globalService';
-import {environment} from '../../environments/environment';
+import { environment } from '../../environments/environment';
 
 
 @Injectable()
@@ -15,11 +15,17 @@ export class CycleService extends GlobalService {
     super();
   }
 
-  getCycles(): Observable<any> {
+  getCycles(isActive: boolean= null): Observable<any> {
     const headers = this.getHeaders();
+    let params = new HttpParams();
+
+    if (isActive != null) {
+      params = params.set('is_active', isActive.toString());
+    }
+
     return this.http.get<any>(
       this.url_cycles,
-      {headers: headers}
+      {headers: headers, params: params}
     );
   }
 }


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | fixed #47

---

## What have you changed ?
Filter cycle to display only active cycle in the homepage

## How did you change it ?
1. Add a conditional HTTP param in the cycle's services.
2. Refactor the homepage to use the new conditional param of the service

## Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 