### PR TITLE
Add possibility to enter start time and end time for Participations

### DIFF
--- a/src/app/components/pages/admin-event/admin-event.component.html
+++ b/src/app/components/pages/admin-event/admin-event.component.html
@@ -56,6 +56,8 @@
         <th>Courriel</th>
         <th>Téléphones</th>
         <th>Type</th>
+        <th>Heure Arrivée</th>
+        <th>Heure Départ</th>
         <th>Durée (minutes)</th>
         <th>Présence</th>
       </tr>
@@ -86,9 +88,33 @@
           <span *ngIf="!participation.standby">Bénévole</span>
         </td>
         <td>
+            <input
+              (focusout)="set_in_time(participation, $event.target.value)"
+              type="number"
+              name="in_time"
+              ng-model="in_time"
+              min="0.00"
+              max="24.00"
+              value="{{ event.start_date | date:'HH'}}"
+              >
+        </td>
+
+        <td>
+          <input
+          (focusout)="set_out_time(participation, $event.target.value)"
+            type="number"
+            name="out_time"
+            ng-model="out_time"
+            min="0.00"
+            max="24.00"
+          >
+        </td>
+        <td>
+          {{ participation.presence_duration_minutes }}
           <input (focusout)="save_participation(participation, 'presence_duration_minutes', $event.target.value)"
                  type="text"
                  value="{{ participation.presence_duration_minutes }}"
+                 hidden
           />
         </td>
         <td>

--- a/src/app/components/pages/admin-event/admin-event.component.ts
+++ b/src/app/components/pages/admin-event/admin-event.component.ts
@@ -70,4 +70,23 @@ export class AdminEventComponent implements OnInit {
       );
     }
   }
+
+  calculate_minutes(participation) {
+    if (participation.in_time && participation.out_time) {
+      participation.presence_duration_minutes = (participation.out_time - participation.in_time) * 60.0;
+      participation.presence_duration_minutes.toFixed(2);
+    }
+  }
+
+  set_in_time(participation, value) {
+    participation.in_time = value;
+    this.calculate_minutes(participation);
+  }
+
+  set_out_time(participation, value) {
+    participation.out_time = value;
+    this.calculate_minutes(participation);
+  }
+
+
 }


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Enhancement
| Tickets (_issues_) concerned               | [62](https://genielibre.com/issues/62)

---

## What have you changed ?
Add possibility to enter start and end time for Participation

## How did you change it ?
Add 2 fields in the participation row

## Verification :
 -  [X] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [X] This Pull-Request fully meets the requirements defined in the issue
 -  [X] I added or modified the attached tests
 