### PR TITLE
Add a btn to download a file with the Participation of the current cell

### DIFF
--- a/src/app/components/pages/admin-cell/admin-cell.component.html
+++ b/src/app/components/pages/admin-cell/admin-cell.component.html
@@ -1,6 +1,8 @@
 <div class="admin-cell" *ngIf="cell">
   <h2>Cellule de {{ cell.name }}</h2>
 
+  <a class="button" (click)="export_link_pressed($event)">Télécharger la liste des Participations</a>
+
   <p>
     <b>Adresse : </b>
     {{ cell.address.address_line1 }},

--- a/src/app/components/pages/admin-cell/admin-cell.component.ts
+++ b/src/app/components/pages/admin-cell/admin-cell.component.ts
@@ -162,4 +162,14 @@ export class AdminCellComponent implements OnInit {
       this.filteredEvents = eventFiltered;
     }
   }
+
+  export_link_pressed(event: any) {
+    event.preventDefault();
+
+    this.cellService.getExportCell(this.cell.id).subscribe(
+        data => {
+          window.location.assign(this.cellService.getExportCellLink(data.export_link));
+        }
+      );
+  }
 }

--- a/src/app/services/cell.service.ts
+++ b/src/app/services/cell.service.ts
@@ -30,4 +30,16 @@ export class CellService extends GlobalService {
       {headers: headers}
     );
   }
+
+  getExportCell(id: number): Observable<any> {
+    const headers = this.getHeaders();
+    return this.http.get<any>(
+      this.url_cells + '/' + id + '/export',
+      {headers: headers}
+    );
+  }
+
+  getExportCellLink(url: string) {
+    return environment.url_base_api + url;
+  }
 }


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | [Features]
| Tickets (_issues_) concerned               | [[67](https://genielibre.com/issues/67)]

---

## What have you changed ?
I have added a button in the Cell Detail page to download the exportation of the Participations of the current Cell

## Verification :
 -  [X] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [X] This Pull-Request fully meets the requirements defined in the issue
 -  [X] I added or modified the attached tests
 