### PR TITLE
add modal to edit participation

### DIFF
--- a/src/app/components/pages/admin-event/admin-event.component.html
+++ b/src/app/components/pages/admin-event/admin-event.component.html
@@ -48,57 +48,64 @@
 
   <div class="admin-event__participations">
     <h2>Participations : </h2>
-    <table class="table">
-      <tr>
-        <th>Nom d'utilisateur</th>
-        <th>Prénom</th>
-        <th>Nom</th>
-        <th>Courriel</th>
-        <th>Téléphones</th>
-        <th>Type</th>
-        <th>Durée (minutes)</th>
-        <th>Présence</th>
-      </tr>
-      <tr *ngIf="participations && participations.length == 0">
-        <td colspan="5">
-          Aucune participations pour le moment.
-        </td>
-      </tr>
-      <tr *ngFor="let participation of participations">
-        <td>
-          {{ participation.user.username }}
-        </td>
-        <td>
-          {{ participation.user.first_name }}
-        </td>
-        <td>
-          {{ participation.user.last_name }}
-        </td>
-        <td>
-          {{ participation.user.email }}
-        </td>
-        <td>
-          <span *ngIf="participation.user.phone">{{ participation.user.phone }}<br/></span>
-          {{ participation.user.mobile }}
-        </td>
-        <td>
-          <span *ngIf="participation.standby">Remplaçant</span>
-          <span *ngIf="!participation.standby">Bénévole</span>
-        </td>
-        <td>
-          <input (focusout)="save_participation(participation, 'presence_duration_minutes', $event.target.value)"
-                 type="text"
-                 value="{{ participation.presence_duration_minutes }}"
-          />
-        </td>
-        <td>
-          <select (change)="save_participation(participation, 'presence_status', $event.target.value)">
-            <option *ngFor="let option of participationStatusOption" value="{{ option.value }}" [selected]="option.value == participation.presence_status">
-              {{ option.name }}
-            </option>
-          </select>
-        </td>
-      </tr>
-    </table>
+    <app-my-table [settings]="settings"
+                  [data]="participationsAdapted"
+                  (editItem)="OpenModalEditParticipation($event)">
+    </app-my-table>
   </div>
 </div>
+
+<app-my-modal name="update participation"
+              title="Modification d'une participation"
+              button2Label="Modifier"
+              (button2)="updateParticipation()"
+              typeModal="form"
+              button2Style="button--success">
+
+  <form [formGroup]="participationForm">
+    <div class="form-group">
+      <label for="presence_status" class="form-label">Présence:</label>
+      <select formControlName="presence_status" id="presence_status" class="input">
+        <option value="" disabled>Choisis un status</option>
+        <option *ngFor="let status of participationStatusOption" [value]="status.value">{{ status.name }}</option>
+      </select>
+      <div class="form-text form-text--right form-text--danger"
+           *ngFor="let errorMessage of participationForm.controls['presence_status'].getError('apiError')">
+        {{ errorMessage}}
+      </div>
+    </div>
+
+    <div class="form-group" *ngIf="event && participationForm.controls['presence_status'].value === 'P'">
+      <label for="start_date" class="form-label">Heure d'arrivée:</label>
+      <input [owlDateTimeTrigger]="dt12" [owlDateTime]="dt12"
+             [max]="event.end_date" formControlName="start_date"
+             class="input" id="start_date">
+      <owl-date-time #dt12 [firstDayOfWeek]="1" [startAt]="event.start_date"></owl-date-time>
+      <div class="form-text form-text--right form-text--danger"
+           *ngFor="let errorMessage of participationForm.controls['start_date'].getError('apiError')">
+        {{ errorMessage}}
+      </div>
+    </div>
+
+    <div class="form-group" *ngIf="event && participationForm.controls['presence_status'].value === 'P'">
+      <label for="end_date" class="form-label">Heure de départ:</label>
+      <input [owlDateTimeTrigger]="dt13" [owlDateTime]="dt13"
+             [min]="event.start_date" formControlName="end_date"
+             class="input" id="end_date">
+      <owl-date-time #dt13 [firstDayOfWeek]="1" [startAt]="event.end_date"></owl-date-time>
+      <div class="form-text form-text--right form-text--danger"
+           *ngFor="let errorMessage of participationForm.controls['end_date'].getError('apiError')">
+        {{ errorMessage}}
+      </div>
+    </div>
+
+    <div class="alert alert--danger" *ngIf="participationForm.hasError('apiError')">
+      <ul>
+        <li *ngFor="let error of participationForm.getError('apiError')">
+          {{error}}
+        </li>participationStatusOption
+      </ul>
+    </div>
+
+  </form>
+</app-my-modal>

--- a/src/app/components/pages/admin-event/admin-event.component.ts
+++ b/src/app/components/pages/admin-event/admin-event.component.ts
@@ -5,6 +5,8 @@ import { EventService } from '../../../services/event.service';
 import { Participation } from '../../../models/participation';
 import { ParticipationService } from '../../../services/participation.service';
 import { NotificationsService } from 'angular2-notifications';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MyModalService } from '../../../services/my-modal/my-modal.service';
 
 
 @Component({
@@ -16,7 +18,45 @@ import { NotificationsService } from 'angular2-notifications';
 export class AdminEventComponent implements OnInit {
 
   event: Event;
+
   participations: Participation[];
+  participationsAdapted: Participation[];
+
+  settings = {
+    editButton: true,
+    columns: [
+      {
+        name: 'first_name',
+        title: 'Prénom'
+      },
+      {
+        name: 'last_name',
+        title: 'Nom'
+      },
+      {
+        name: 'email',
+        title: 'Courriel'
+      },
+      {
+        name: 'phone',
+        title: 'Téléphones'
+      },
+      {
+        name: 'standby',
+        title: 'Remplacant',
+        type: 'boolean'
+      },
+      {
+        name: 'presence_duration_minutes',
+        title: 'Durée (minutes)'
+      },
+      {
+        name: 'presence_status',
+        title: 'Présence'
+      }
+    ]
+  };
+
   participationStatusOption = [
     {
       value: 'I',
@@ -32,10 +72,15 @@ export class AdminEventComponent implements OnInit {
     },
   ];
 
+  participationForm: FormGroup;
+  selectedParticipation: Participation;
+
   constructor(private activatedRoute: ActivatedRoute,
               private eventService: EventService,
               private participationService: ParticipationService,
-              private notificationService: NotificationsService) {}
+              private notificationService: NotificationsService,
+              private formBuilder: FormBuilder,
+              private myModalService: MyModalService) {}
 
   ngOnInit() {
     this.activatedRoute.params.subscribe((params: Params) => {
@@ -46,28 +91,131 @@ export class AdminEventComponent implements OnInit {
         }
       );
     });
+
+    this.participationForm = this.formBuilder.group(
+      {
+        presence_status: [0, [Validators.required]],
+        start_date: [0],
+        end_date: [0],
+      },
+      {
+        validator: this.dateValidator()
+      }
+    );
   }
 
   get_participations() {
     this.participationService.getParticipations(this.event.id).subscribe(
       data => {
-        this.participations = data.results.map(p => new Participation(p) );
+        this.participations = data.results.map(p => new Participation(p));
+        this.participationsAdapted = this.participationAdapter(this.participations);
       }
     );
   }
 
-  save_participation(participation, field, value) {
-    if (value && participation[field] !== value) {
-      const buffer = participation[field];
-      participation[field] = value;
-      this.participationService.updateParticipation(participation).subscribe(
-        data => {
-          participation = data;
+  updateParticipation() {
+    const data = {};
+    data['presence_status'] = this.participationForm.value['presence_status'];
+
+    if (this.participationForm.value['start_date'] && this.participationForm.value['end_date']) {
+      const start = new Date(this.participationForm.value['start_date']).getTime();
+      const end = new Date(this.participationForm.value['end_date']).getTime();
+      data['presence_duration_minutes'] = (end - start) / 60000;
+    }
+
+    console.log(data);
+
+    if (this.participationForm.valid) {
+      this.participationService.updateParticipation(this.selectedParticipation.id, data).subscribe(
+        success => {
+          this.toogleModal();
+          this.notificationService.success('Modification réussie',
+            `La participation a été modifié`);
+
+          this.get_participations();
         },
-        error => {
-          participation[field] = buffer;
+        err => {
+          if (err.error.presence_status) {
+            this.participationForm.controls['presence_status'].setErrors({
+              apiError: err.error.presence_status
+            });
+          }
+          if (err.error.non_field_errors) {
+            this.participationForm.setErrors({
+              apiError: err.error.non_field_errors
+            });
+          }
         }
       );
+    } else {
+      for (const controlKey of Object.keys(this.participationForm.controls)) {
+        this.participationForm.controls[controlKey].markAsTouched();
+      }
     }
+  }
+
+  dateValidator() {
+    return (group: FormGroup) => {
+
+      const date_start = group.controls['start_date'];
+      const date_end = group.controls['end_date'];
+
+      if (date_start.value && !date_end.value) {
+        return date_end.setErrors({
+          apiError: ['Si une date de début est saisie, la date de fin est obligatoire.']
+        });
+      } else if (!date_start.value && date_end.value) {
+        return date_start.setErrors({
+          apiError: ['Si une date de fin est saisie, la date de début est obligatoire.']
+        });
+      } else if (date_start.value && date_end.value && date_start.value >= date_end.value) {
+        return date_end.setErrors({
+          apiError: ['La fin de la plage horaire doit être après le début de la plage horaire.']
+        });
+      }
+    };
+  }
+
+  OpenModalEditParticipation(event) {
+    this.participationForm.reset();
+    for (const participation of this.participations) {
+      if (participation.id === event.id) {
+        this.selectedParticipation = participation;
+        this.participationForm.controls['presence_status'].setValue(participation.presence_status);
+        this.toogleModal();
+      }
+    }
+  }
+
+  toogleModal() {
+    const modal = this.myModalService.get('update participation');
+
+    if (!modal) {
+      console.error('No modal named %s', 'update participation');
+      return;
+    }
+    modal.toggle();
+  }
+
+  participationAdapter(participations) {
+    const participationsAdapted = [];
+    for (const participation of participations) {
+      const newParticipation = {
+        id: participation.id,
+        first_name: participation.user.first_name,
+        last_name: participation.user.last_name,
+        email: participation.user.email,
+        phone: participation.user.phone,
+        standby: participation.standby,
+        presence_duration_minutes: participation.presence_duration_minutes,
+      };
+      for (const status of this.participationStatusOption) {
+        if (status.value === participation.presence_status) {
+          newParticipation['presence_status'] = status.name;
+        }
+      }
+      participationsAdapted.push(newParticipation);
+    }
+    return participationsAdapted;
   }
 }

--- a/src/app/models/participation.ts
+++ b/src/app/models/participation.ts
@@ -1,5 +1,5 @@
 import BaseModel from './baseModel';
-import {User} from './user';
+import { User } from './user';
 
 export class Participation extends BaseModel {
   id: number;
@@ -21,18 +21,6 @@ export class Participation extends BaseModel {
       return 'Présent';
     }
     return '';
-  }
-
-  serialize() {
-    const data = {
-      presence_status: this.presence_status,
-    };
-
-    if (this.presence_duration_minutes) {
-      data['presence_duration_minutes'] = this.presence_duration_minutes;
-    }
-
-    return data;
   }
 }
 

--- a/src/app/services/participation.service.ts
+++ b/src/app/services/participation.service.ts
@@ -30,11 +30,11 @@ export class ParticipationService extends GlobalService {
       );
   }
 
-  updateParticipation(participation: Participation) {
+  updateParticipation(id: number, data: any) {
     const headers = this.getHeaders();
     return this.http.patch<any>(
-      this.url_participations + '/' + participation.id,
-      participation.serialize(),
+      this.url_participations + '/' + id,
+      data,
       {headers: headers}
     );
   }


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Enhancement
| Tickets (_issues_) concerned               | [62](https://genielibre.com/issues/62)

---

## What have you changed ?
Add a modal to edit participation with two datetimes to help the administrator to enter the exact number of minutes.

## How did you change it ?
 - Refactor table to use `my-table` components instead of a custom `<table>`
 - Add a modal to edit the participation
 - Add two datetimes selector in the modal

## Screenshots
![screenshot-2018-6-7 volontaria](https://user-images.githubusercontent.com/12053720/41107443-59787f1a-6a40-11e8-8fa9-365462b45b4a.png)
![screenshot-2018-6-7 volontaria 1](https://user-images.githubusercontent.com/12053720/41107448-5b5727e6-6a40-11e8-92f2-fa6cfba41319.png)
![screenshot-2018-6-7 volontaria 2](https://user-images.githubusercontent.com/12053720/41107449-5cec5c66-6a40-11e8-845f-b9489bd9cb9f.png)
![screenshot-2018-6-7 volontaria 3](https://user-images.githubusercontent.com/12053720/41107460-5fe9a0fe-6a40-11e8-882c-cfc750e2c4a2.png)


## Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 