### PR TITLE
Fix multiselect dropdown checkbox labels line wrapping

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,3 +2,10 @@
 @import "~ng-pick-datetime/assets/style/picker.min.css";
 @import "assets/scss/app";
 @import "~flexboxgrid-sass";
+
+/* Fixes misaligned angular2-multiselect-dropdown checkbox label line wrapping */
+.pure-checkbox {
+  input[type="checkbox"] + label {
+    display: inline-block;
+  }
+}


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | Bug 88: Bad display of the multi-select component

---

## What have you changed ?
Fixed layouting to better handle long text wrapping

## How did you change it ?
Made checkbox label display as inline-block. The idea is taken from the official angular2-multiselect-dropdown demo page (https://cuppalabs.github.io/angular2-multiselect-dropdown/), which properly handles line-wrapping.

Tested on Chromium + Firefox.
Post-fix screenshot:
![Overflow after fix](https://user-images.githubusercontent.com/12588253/54481067-83d09780-4806-11e9-8c5d-6fce251039e3.png)

## Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 
