### PR TITLE
Add a anchor to scroll to the event section when clicking on calendar

### DIFF
--- a/src/app/components/pages/activities-page/activities-page.component.html
+++ b/src/app/components/pages/activities-page/activities-page.component.html
@@ -56,7 +56,7 @@
       </div>
     </div>
     <div class="activities-page__activities__infos">
-      <div *ngIf="clickedDay" class="activities-page__activities__infos__details">
+      <div *ngIf="clickedDay" class="activities-page__activities__infos__details" id="anchor_list_events">
         <h2 class="title title--secondary">
           Liste des plages horaires du {{ clickedDay | date:"dd MMMM yyyy"}}:
         </h2>

--- a/src/app/components/pages/activities-page/activities-page.component.ts
+++ b/src/app/components/pages/activities-page/activities-page.component.ts
@@ -80,7 +80,7 @@ export class ActivitiesPageComponent implements OnInit {
   ];
 
   eventsOfDay = [];
-  clickedDay = null;
+  clickedDay = new Date();
   settings = {
     noDataText: 'Aucune plage horaire pour ce jour.',
     clickable: true,
@@ -287,6 +287,7 @@ export class ActivitiesPageComponent implements OnInit {
         }
       }
     }
+    this.onAnchorClick();
   }
 
   eventClicked(eventClicked) {
@@ -311,6 +312,13 @@ export class ActivitiesPageComponent implements OnInit {
       nb_standby: event.nb_volunteers_standby + '/' + event.nb_volunteers_standby_needed
     };
     return newEvent;
+  }
+
+  onAnchorClick() {
+    let x = document.querySelector("#anchor_list_events");
+    if (x) {
+      x.scrollIntoView();
+    }
   }
 
   toggleModal(name) {


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | [Features]
| Tickets (_issues_) concerned               | [[129](https://genielibre.com/issues/129)]

---

## What have you changed ? 
On the activity calendar page, when we click on a day, the web page now scroll to show the sometime hidden event section bellow it.

## Verification :
 -  [X] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [X] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 