### PR TITLE
Add the possibility to reset a password using the username or email

### DIFF
--- a/src/app/components/pages/forgot-password/forgot-password.component.html
+++ b/src/app/components/pages/forgot-password/forgot-password.component.html
@@ -6,10 +6,10 @@
 
   <form (submit)="resetPassword(forgotForm)" [formGroup]="forgotForm" class="forgot-password-page__form">
     <div class="form-group">
-      <label for="username" class="form-label">Nom d'utilisateur associé à votre compte:</label>
-      <input formControlName="username" type="text" id="username" class="input" />
+      <label for="username_email" class="form-label">Nom d'utilisateur ou courriel associé à votre compte:</label>
+      <input formControlName="username_email" type="text" id="username_email" class="input" />
       <div class="form-text form-text--right form-text--danger"
-           *ngFor="let errorMessage of forgotForm.controls['username'].getError('apiError')">
+           *ngFor="let errorMessage of forgotForm.controls['username_email'].getError('apiError')">
         {{ errorMessage }}
       </div>
     </div>

--- a/src/app/components/pages/forgot-password/forgot-password.component.ts
+++ b/src/app/components/pages/forgot-password/forgot-password.component.ts
@@ -18,26 +18,24 @@ export class ForgotPasswordComponent {
               private router: Router) {
     this.forgotForm = this.formBuilder.group(
       {
-        username: null,
+        username_email: null,
       }
     );
   }
 
   resetPassword(form: FormGroup) {
     if ( form.valid ) {
-      this.authenticationService.resetPassword(form.value['username']).subscribe(
+      this.authenticationService.resetPassword(form.value['username_email']).subscribe(
         data => {
-          console.log('success');
           this.router.navigate(['/forgot-password/confirmation']);
         },
         err => {
           if (err.error.non_field_errors) {
             this.errors = err.error.non_field_errors;
-            console.log(this.errors);
           }
-          if (err.error.username) {
-            this.forgotForm.controls['username'].setErrors({
-              apiError: err.error.username
+          if (err.error.username_email) {
+            this.forgotForm.controls['username_email'].setErrors({
+              apiError: err.error.username_email
             });
           }
         }

--- a/src/app/services/authentication.service.ts
+++ b/src/app/services/authentication.service.ts
@@ -33,12 +33,12 @@ export class AuthenticationService extends GlobalService {
     );
   }
 
-  resetPassword(email: string): Observable<any> {
+  resetPassword(username_email: string): Observable<any> {
     const headers = this.getHeaders();
     return this.http.post<any>(
       this.url_reset_password,
       {
-        username: email
+        username_email: username_email
       },
       {headers: headers}
     );


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | [Enhancement]
| Tickets (_issues_) concerned               | [[251]](https://genielibre.com/issues/251)

Need the merge of API-Volontaria [234](https://github.com/Volontaria/API-Volontaria/pull/234)

## What have you changed ?
Add the possibility to reset a password using username or email

<img width="481" alt="Screen Shot 2019-07-17 at 3 16 23 PM" src="https://user-images.githubusercontent.com/22125499/61406407-ccc65480-a8a9-11e9-94e3-4d6291d8d02d.png">

## Verification :
 -  [X] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [X] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 