### PR TITLE
Add WooComerce coupon display on user profile page

### DIFF
--- a/src/app/components/pages/myschedule-page/myschedule-page.component.html
+++ b/src/app/components/pages/myschedule-page/myschedule-page.component.html
@@ -42,6 +42,20 @@
       </tr>
     </table>
   </div>
+  <div class="myschedule__account" *ngIf="user && user.coupon.code">
+    <h1 class="title title--main">Mon coupon</h1>
+    <table class="table">
+      <tr>
+        <th>Code</th>
+        <td>{{ user.coupon.code }}</td>
+      </tr>
+      <tr>
+        <th>Solde</th>
+        <td>{{ user.coupon.balance }}</td>
+      </tr>
+    </table>
+  </div>
+
   <div class="myschedule__volunteer">
     <h1 class="title title--main">Mon horaire - Bénévole</h1>
     <table class="table">

--- a/src/app/models/user.ts
+++ b/src/app/models/user.ts
@@ -1,6 +1,11 @@
 import BaseModel from './baseModel';
 import { Cell } from './cell';
 
+export class Coupon extends BaseModel {
+  code: string;
+  balance: string;
+}
+
 export class User extends BaseModel {
   id: number;
   username: string;
@@ -12,6 +17,7 @@ export class User extends BaseModel {
   is_active: boolean;
   is_superuser: boolean;
   managed_cell: Cell[];
+  coupon: Coupon;
 }
 
 


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | [Features]
| Tickets (_issues_) concerned               | [[186]](https://genielibre.com/issues/186)

---

REQUIRE the merge of APPI-Volontaria : [237](https://github.com/Volontaria/API-Volontaria/pull/237)

## What have you changed ?
Added a coupon section in the User profile

<img width="1366" alt="Screen Shot 2019-07-22 at 2 48 11 PM" src="https://user-images.githubusercontent.com/22125499/61656912-c19b6c00-ac8f-11e9-88c1-a8273ba727e3.png">


## Verification :
 -  [X] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [X] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 